### PR TITLE
feat(transition): add backwards anims

### DIFF
--- a/internal/tui/slide.go
+++ b/internal/tui/slide.go
@@ -50,7 +50,12 @@ func (s Slide) view() string {
 	}
 
 	if s.Properties.Transition != nil && s.Properties.Transition.Animating() {
-		b.WriteString(s.Properties.Transition.View(s.Prev.View(), s.Style.Render(out)))
+		direction := s.Properties.Transition.Direction()
+		if direction == transitions.Backwards {
+			b.WriteString(s.Properties.Transition.View(s.Next.View(), s.Style.Render(out)))
+		} else {
+			b.WriteString(s.Properties.Transition.View(s.Prev.View(), s.Style.Render(out)))
+		}
 	} else {
 		b.WriteString(s.Style.Render(out))
 	}

--- a/internal/tui/slide.go
+++ b/internal/tui/slide.go
@@ -63,8 +63,9 @@ func (s Slide) view() string {
 }
 
 type Properties struct {
-	Style      StyleConfig            `yaml:"style"`
-	Transition transitions.Transition `yaml:"transition"`
+	Style               StyleConfig            `yaml:"style"`
+	Transition          transitions.Transition `yaml:"transition"`
+	_OriginalTransition transitions.Transition // Should never be mutated
 }
 
 func (p *Properties) UnmarshalYAML(bytes []byte) error {
@@ -76,7 +77,9 @@ func (p *Properties) UnmarshalYAML(bytes []byte) error {
 	if err := yaml.Unmarshal(bytes, &aux); err != nil {
 		return err
 	}
-	p.Transition = transitions.Get(aux.Transition, fps)
+	transition := transitions.Get(aux.Transition, fps)
+	p.Transition = transition
+	p._OriginalTransition = transition
 	p.Style = aux.Style
 
 	return nil
@@ -84,7 +87,11 @@ func (p *Properties) UnmarshalYAML(bytes []byte) error {
 
 func NewProperties(properties string) (Properties, error) {
 	if properties == "" {
-		return Properties{Transition: transitions.Get("default", fps)}, nil
+		transition := transitions.Get("default", fps)
+		return Properties{
+			Transition:          transition,
+			_OriginalTransition: transition,
+		}, nil
 	}
 
 	var p Properties

--- a/internal/tui/transitions/flip_right.go
+++ b/internal/tui/transitions/flip_right.go
@@ -20,6 +20,7 @@ type flipRight struct {
 	x         float64
 	xVel      float64
 	animating bool
+	direction direction
 }
 
 func newFlipRight(fps int) flipRight {
@@ -37,6 +38,7 @@ func (t flipRight) Start(width int, _ int) Transition {
 	t.animating = true
 	t.x = 0
 	t.xVel = 0
+	t.direction = direction
 	return t
 }
 
@@ -89,4 +91,8 @@ func (t flipRight) Name() string {
 
 func (t flipRight) Opposite() Transition {
 	return t
+}
+
+func (t flipRight) Direction() direction {
+	return t.direction
 }

--- a/internal/tui/transitions/flip_right.go
+++ b/internal/tui/transitions/flip_right.go
@@ -33,7 +33,7 @@ func newFlipRight(fps int) flipRight {
 	}
 }
 
-func (t flipRight) Start(width int, _ int) Transition {
+func (t flipRight) Start(width int, _ int, direction direction) Transition {
 	t.width = width
 	t.animating = true
 	t.x = 0

--- a/internal/tui/transitions/flip_right.go
+++ b/internal/tui/transitions/flip_right.go
@@ -82,3 +82,11 @@ func (t flipRight) View(prev string, next string) string {
 
 	return s.String()
 }
+
+func (t flipRight) Name() string {
+	return "flipRight"
+}
+
+func (t flipRight) Opposite() Transition {
+	return t
+}

--- a/internal/tui/transitions/none.go
+++ b/internal/tui/transitions/none.go
@@ -23,3 +23,11 @@ func (t noTransition) Update() (Transition, tea.Cmd) {
 func (notransition noTransition) View(prev string, next string) string {
 	return ""
 }
+
+func (t noTransition) Name() string {
+	return "none"
+}
+
+func (t noTransition) Opposite() Transition {
+	return t
+}

--- a/internal/tui/transitions/none.go
+++ b/internal/tui/transitions/none.go
@@ -31,3 +31,8 @@ func (t noTransition) Name() string {
 func (t noTransition) Opposite() Transition {
 	return t
 }
+
+func (t noTransition) Direction() direction {
+	// don't care, no anim
+	return Forwards
+}

--- a/internal/tui/transitions/none.go
+++ b/internal/tui/transitions/none.go
@@ -8,7 +8,7 @@ func newNoTransition(_ int) noTransition {
 	return noTransition{}
 }
 
-func (t noTransition) Start(width int, height int) Transition {
+func (t noTransition) Start(width int, height int, direction direction) Transition {
 	return t
 }
 

--- a/internal/tui/transitions/slide_down.go
+++ b/internal/tui/transitions/slide_down.go
@@ -74,3 +74,11 @@ func (t slideDown) View(prev, next string) string {
 
 	return s.String()
 }
+
+func (t slideDown) Name() string {
+	return "slideDown"
+}
+
+func (t slideDown) Opposite() Transition {
+	return newSlideUp(t.fps)
+}

--- a/internal/tui/transitions/slide_down.go
+++ b/internal/tui/transitions/slide_down.go
@@ -18,6 +18,7 @@ type slideDown struct {
 	y         float64
 	yVel      float64
 	animating bool
+	direction direction
 }
 
 func newSlideDown(fps int) slideDown {
@@ -35,6 +36,7 @@ func (t slideDown) Start(_, height int) Transition {
 	t.animating = true
 	t.y = 0
 	t.yVel = 0
+	t.direction = direction
 	return t
 }
 
@@ -81,4 +83,8 @@ func (t slideDown) Name() string {
 
 func (t slideDown) Opposite() Transition {
 	return newSlideUp(t.fps)
+}
+
+func (t slideDown) Direction() direction {
+	return t.direction
 }

--- a/internal/tui/transitions/slide_down.go
+++ b/internal/tui/transitions/slide_down.go
@@ -31,7 +31,7 @@ func newSlideDown(fps int) slideDown {
 	}
 }
 
-func (t slideDown) Start(_, height int) Transition {
+func (t slideDown) Start(_, height int, direction direction) Transition {
 	t.height = height
 	t.animating = true
 	t.y = 0

--- a/internal/tui/transitions/slide_up.go
+++ b/internal/tui/transitions/slide_up.go
@@ -31,7 +31,7 @@ func newSlideUp(fps int) slideUp {
 	}
 }
 
-func (t slideUp) Start(_, height int) Transition {
+func (t slideUp) Start(_, height int, direction direction) Transition {
 	t.height = height
 	t.animating = true
 	t.y = 0

--- a/internal/tui/transitions/slide_up.go
+++ b/internal/tui/transitions/slide_up.go
@@ -70,3 +70,11 @@ func (t slideUp) View(prev, next string) string {
 
 	return s.String()
 }
+
+func (t slideUp) Name() string {
+	return "slideUp"
+}
+
+func (t slideUp) Opposite() Transition {
+	return newSlideDown(t.fps)
+}

--- a/internal/tui/transitions/slide_up.go
+++ b/internal/tui/transitions/slide_up.go
@@ -18,6 +18,7 @@ type slideUp struct {
 	y         float64
 	yVel      float64
 	animating bool
+	direction direction
 }
 
 func newSlideUp(fps int) slideUp {
@@ -35,6 +36,7 @@ func (t slideUp) Start(_, height int) Transition {
 	t.animating = true
 	t.y = 0
 	t.yVel = 0
+	t.direction = direction
 	return t
 }
 
@@ -77,4 +79,8 @@ func (t slideUp) Name() string {
 
 func (t slideUp) Opposite() Transition {
 	return newSlideDown(t.fps)
+}
+
+func (t slideUp) Direction() direction {
+	return t.direction
 }

--- a/internal/tui/transitions/swipe_left.go
+++ b/internal/tui/transitions/swipe_left.go
@@ -33,7 +33,7 @@ func newSwipeLeft(fps int) swipeLeft {
 	}
 }
 
-func (t swipeLeft) Start(width int, _ int) Transition {
+func (t swipeLeft) Start(width int, _ int, direction direction) Transition {
 	t.width = width
 	t.animating = true
 	t.x = 0

--- a/internal/tui/transitions/swipe_left.go
+++ b/internal/tui/transitions/swipe_left.go
@@ -20,6 +20,7 @@ type swipeLeft struct {
 	x         float64
 	xVel      float64
 	animating bool
+	direction direction
 }
 
 func newSwipeLeft(fps int) swipeLeft {
@@ -37,6 +38,7 @@ func (t swipeLeft) Start(width int, _ int) Transition {
 	t.animating = true
 	t.x = 0
 	t.xVel = 0
+	t.direction = direction
 	return t
 }
 
@@ -87,4 +89,8 @@ func (t swipeLeft) Name() string {
 
 func (t swipeLeft) Opposite() Transition {
 	return newSwipeRight(t.fps)
+}
+
+func (t swipeLeft) Direction() direction {
+	return t.direction
 }

--- a/internal/tui/transitions/swipe_left.go
+++ b/internal/tui/transitions/swipe_left.go
@@ -80,3 +80,11 @@ func (t swipeLeft) View(prev string, next string) string {
 	}
 	return s.String()
 }
+
+func (t swipeLeft) Name() string {
+	return "swipeLeft"
+}
+
+func (t swipeLeft) Opposite() Transition {
+	return newSwipeRight(t.fps)
+}

--- a/internal/tui/transitions/swipe_right.go
+++ b/internal/tui/transitions/swipe_right.go
@@ -79,4 +79,12 @@ func (t swipeRight) View(prev string, next string) string {
 		}
 	}
 	return s.String()
-} 
+}
+
+func (t swipeRight) Name() string {
+	return "swipeRight"
+}
+
+func (t swipeRight) Opposite() Transition {
+	return newSwipeLeft(t.fps)
+}

--- a/internal/tui/transitions/swipe_right.go
+++ b/internal/tui/transitions/swipe_right.go
@@ -33,7 +33,7 @@ func newSwipeRight(fps int) swipeRight {
 	}
 }
 
-func (t swipeRight) Start(width int, _ int) Transition {
+func (t swipeRight) Start(width int, _ int, direction direction) Transition {
 	t.width = width
 	t.animating = true
 	t.x = 0

--- a/internal/tui/transitions/swipe_right.go
+++ b/internal/tui/transitions/swipe_right.go
@@ -20,6 +20,7 @@ type swipeRight struct {
 	x         float64
 	xVel      float64
 	animating bool
+	direction direction
 }
 
 func newSwipeRight(fps int) swipeRight {
@@ -37,6 +38,7 @@ func (t swipeRight) Start(width int, _ int) Transition {
 	t.animating = true
 	t.x = 0
 	t.xVel = 0
+	t.direction = direction
 	return t
 }
 
@@ -87,4 +89,8 @@ func (t swipeRight) Name() string {
 
 func (t swipeRight) Opposite() Transition {
 	return newSwipeLeft(t.fps)
+}
+
+func (t swipeRight) Direction() direction {
+	return t.direction
 }

--- a/internal/tui/transitions/transition.go
+++ b/internal/tui/transitions/transition.go
@@ -16,6 +16,7 @@ type Transition interface {
 	View(prev, next string) string
 	Opposite() Transition
 	Name() string
+	Direction() direction
 }
 
 func Get(name string, fps int) Transition {

--- a/internal/tui/transitions/transition.go
+++ b/internal/tui/transitions/transition.go
@@ -2,6 +2,13 @@ package transitions
 
 import tea "github.com/charmbracelet/bubbletea"
 
+type direction byte
+
+const (
+	Forwards  direction = 0
+	Backwards direction = 1
+)
+
 type Transition interface {
 	Start(width, height int) Transition
 	Animating() bool

--- a/internal/tui/transitions/transition.go
+++ b/internal/tui/transitions/transition.go
@@ -10,7 +10,7 @@ const (
 )
 
 type Transition interface {
-	Start(width, height int) Transition
+	Start(width, height int, direction direction) Transition
 	Animating() bool
 	Update() (Transition, tea.Cmd)
 	View(prev, next string) string

--- a/internal/tui/transitions/transition.go
+++ b/internal/tui/transitions/transition.go
@@ -7,6 +7,8 @@ type Transition interface {
 	Animating() bool
 	Update() (Transition, tea.Cmd)
 	View(prev, next string) string
+	Opposite() Transition
+	Name() string
 }
 
 func Get(name string, fps int) Transition {

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -93,13 +93,15 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 			m.slide = m.slide.Next
-			m.slide.Properties.Transition = m.slide.Properties.Transition.Start(m.width, m.height, transitions.Forwards)
+			transition := transitions.Get(m.slide.Properties._OriginalTransition.Name(), fps)
+			m.slide.Properties.Transition = transition.Start(m.width, m.height, transitions.Forwards)
 			return m, messages.Animate(fps)
 		} else if key.Matches(msg, m.keys.Prev) {
 			if m.slide.Prev == nil || m.slide.Properties.Transition.Animating() {
 				return m, nil
 			}
-			transition := transitions.Get(m.slide.Properties.Transition.Name(), fps).Opposite()
+			oppositeName := m.slide.Properties._OriginalTransition.Opposite().Name()
+			transition := transitions.Get(oppositeName, fps)
 			m.slide = m.slide.Prev
 			m.slide.Properties.Transition = transition.Start(m.width, m.height, transitions.Backwards)
 			return m, messages.Animate(fps)

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -7,6 +7,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/ploMP4/kyma/internal/tui/messages"
+	"github.com/ploMP4/kyma/internal/tui/transitions"
 )
 
 type keyMap struct {
@@ -92,13 +93,15 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 			m.slide = m.slide.Next
-			m.slide.Properties.Transition = m.slide.Properties.Transition.Start(m.width, m.height)
+			m.slide.Properties.Transition = m.slide.Properties.Transition.Start(m.width, m.height, transitions.Forwards)
 			return m, messages.Animate(fps)
 		} else if key.Matches(msg, m.keys.Prev) {
 			if m.slide.Prev == nil || m.slide.Properties.Transition.Animating() {
 				return m, nil
 			}
+			transition := transitions.Get(m.slide.Properties.Transition.Name(), fps).Opposite()
 			m.slide = m.slide.Prev
+			m.slide.Properties.Transition = transition.Start(m.width, m.height, transitions.Backwards)
 			return m, messages.Animate(fps)
 		}
 	case messages.FrameMsg:


### PR DESCRIPTION
# feat(transitions): add directional support for slide transitions

### TLDR
Add direction parameter to transitions to enable proper backward navigation with opposite animations.

## Change Summary
#### Added Features:
1. **Direction support in `internal/tui/transitions/transition.go`**:
   - Added `direction` type with `Forwards` and `Backwards` constants
   - Extended `Transition` interface with `Direction()` method
   - Modified `Start()` method to accept direction parameter

2. **Original transition tracking in `internal/tui/slide.go`**:
   - Added `_OriginalTransition` field to preserve initial transition state
   - Updated `Properties` struct to maintain both current and original transitions
   - Modified `view()` method to handle backward transitions correctly

#### Code Changes:
1. **In all transition implementations (flip_right.go, slide_down.go, slide_up.go, swipe_left.go, swipe_right.go)**:
   - Added `direction` field to transition structs
   - Implemented `Direction()` method for all transitions
   - Updated `Start()` methods to accept and store direction parameter

2. **In `internal/tui/tui.go`**:
   - Added directional navigation logic for next/prev slide operations
   - Used `Forwards` direction for next slide navigation
   - Used `Backwards` direction with opposite transition for previous slide

3. **In `internal/tui/slide.go`**:
   - Modified view rendering to swap prev/next slides when animating backwards
   - Updated unmarshal and property initialization to preserve original transitions

### Context
- Previous implementation didn't properly handle backward navigation animations
- The original transition is preserved to maintain the correct opposite transition when navigating backwards