### PR TITLE
fix: timer block issue

### DIFF
--- a/internal/tui/overlay.go
+++ b/internal/tui/overlay.go
@@ -68,8 +68,6 @@ func placeOverlay(x, y int, fg, bg string, opts ...WhitespaceOption) string {
 
 	var b strings.Builder
 
-	b.WriteString("\x1b_Ga=d\x1b\\")
-
 	for i, bgLine := range bgLines {
 		if i > 0 {
 			b.WriteByte('\n')

--- a/internal/tui/slide.go
+++ b/internal/tui/slide.go
@@ -49,11 +49,7 @@ func (s *Slide) Update() (*Slide, tea.Cmd) {
 	transition, cmd := s.ActiveTransition.Update()
 	s.ActiveTransition = transition
 
-	// Update timer
-	// var timerCmd tea.Cmd
-	// s.Timer, timerCmd = s.Timer.Update(TimerTickMsg{})
-
-	return s, tea.Batch(cmd)
+	return s, cmd
 }
 
 func (s *Slide) View(animating bool) string {

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -1,7 +1,9 @@
 package tui
 
 import (
+	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/charmbracelet/bubbles/help"
 	"github.com/charmbracelet/bubbles/key"
@@ -159,9 +161,9 @@ func (m model) Init() tea.Cmd {
 
 	return tea.Batch(
 		tea.ClearScreen,
-		// tea.Tick(time.Second, func(time.Time) tea.Msg {
-		// 	return TimerTickMsg{}
-		// }),
+		tea.Tick(time.Second, func(time.Time) tea.Msg {
+			return TimerTickMsg{}
+		}),
 	)
 }
 
@@ -323,10 +325,11 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		slide, cmd := m.slide.Update()
 		m.slide = slide
 		return m, cmd
-		// case TimerTickMsg:
-		// 	var cmd tea.Cmd
-		// 	m.globalTimer, cmd = m.globalTimer.Update(msg)
-		// 	return m, cmd
+	case TimerTickMsg:
+		var cmd tea.Cmd
+		m.globalTimer, cmd = m.globalTimer.Update(msg)
+		m.slide.Timer, _ = m.slide.Timer.Update(msg)
+		return m, cmd
 	}
 
 	return m, nil
@@ -350,10 +353,12 @@ func (m model) View() string {
 	)
 
 	if m.command != nil && m.command.IsShowing() {
+		fmt.Print("\x1b_Ga=d\x1b\\")
 		return m.command.Show(slideView, m.width, m.height)
 	}
 
 	if m.goTo != nil && m.goTo.IsShowing() {
+		fmt.Print("\x1b_Ga=d\x1b\\")
 		return m.goTo.Show(slideView, m.width, m.height)
 	}
 


### PR DESCRIPTION
This PR fixes the app-freezing issue that sometimes occurs. Turns out that the problem was way simpler than we initially thought. On each animation frame we send a `FrameMsg` that updates the slide which batches a `FrameMsg` along with another `TickMsg` , on each `TickMsg` since we also update the globalTimer we send another `TickMsg` and this keeps going until the app halts.

The fix is just to update both timers on the same `TickMsg` and send only a single one back to bubbletea's event loop so there is only a single `TickMsg`.